### PR TITLE
Improved curve performance

### DIFF
--- a/ControlItems.py
+++ b/ControlItems.py
@@ -732,7 +732,7 @@ class ControlPin(QtGui.QGraphicsItem):
                 self.pinTie.drawTie()
 
             # If there is a node then it will be moved, so update the curve that runs through it
-            if self.getNode(): self.getNode().curveUpdate()
+            if self.getNode(): self.getNode().dirtyCurve()
         return QtGui.QGraphicsItem.itemChange(self, change, value)
 
 
@@ -1111,13 +1111,15 @@ class Node(QtGui.QGraphicsItem):
             self.setPos(QtCore.QPointF(0,0))
             if self.pinTie:
                 self.pinTie().drawTie()
-            self.curveUpdate() # Redraw the curve that is going through the WireGroup
+            self.dirtyCurve() # Redraw the curve that is going through the WireGroup
         else:
             print "WARNING : NODE HAS NO ASSOCIATED PIN AND AS SUCH HAS NO HOME TO GO TO :("
 
-    def curveUpdate(self):
+    def dirtyCurve(self):
+        "Marks any associated curves as dirty"
+
         for rigCurve in self.rigCurveList:
-            rigCurve().buildCurve() 
+            rigCurve().dirtyCurve()
 
     def boundingRect(self):
         adjust = 2
@@ -1157,7 +1159,7 @@ class Node(QtGui.QGraphicsItem):
             if self.pinTie:
                 # print "There is a tie"
                 self.pinTie().drawTie()
-            self.curveUpdate() # The node movement requires redrawing of the WireGroup Curve
+            self.dirtyCurve() # The node movement requires redrawing of the WireGroup Curve
             if self.getPin(): #Check to see if there is a pin
                 if self.getPin().getConstraintItem(): #check to see if there is a constraint Item
                     if type(self.getPin().getConstraintItem()) == ConstraintLine: # We have the special case of the ConstraintLine in place
@@ -1354,7 +1356,7 @@ class SuperNode(Node):
             self.setPos(QtCore.QPointF(0,0))
             if self.pinTie:
                 self.pinTie().drawTie()
-            self.curveUpdate() # The SuperNode movement requires redrawing of the Curve if there is one
+            self.dirtyCurve() # The SuperNode movement requires redrawing of the Curve if there is one
             for skinPin in self.skinnedPins: 
                 skinPin.goHome()
                 homeNode = skinPin.getPin().getNode()

--- a/SupportItems.py
+++ b/SupportItems.py
@@ -146,24 +146,30 @@ class PinTie(QtGui.QGraphicsItem):
 
 
 class RigCurve(QtGui.QGraphicsItem):
-    """This the graphics Item that serves to draw the curve that connects all the nodes together in a WireGroup
+    """Draws the curve that connects all the nodes together in a WireGroup
 
-       The user cannot interact with this curve, it is drawn automaticall when a Node or ControlPin is moved
-       
-       Currently, this curve is very intensive, and needs optimising in a serious way using dirty bits to 
-       limit the number of times the redraw is calculated. Investigate this!  
+    The user cannot interact with this curve, it is drawn automaticall when a Node or ControlPin is moved
+
+    Currently, this curve is very intensive, and needs optimising in a serious way using dirty bits to 
+    limit the number of times the redraw is calculated. Investigate this!  
     """
     def __init__(self, color, controlNodes, parent=None, scene=None):
         super(RigCurve, self).__init__(parent, scene)
+
         self.selected = False
         self.color = color
         self.nodeList = self.getNodeList(controlNodes)
         self.curveSwing = 0.25
         self.handlescale = 0.3
         self.secondHandleScale = 0.5
+        self.dirty = True
+
+        # Set Draw sorting order - 0 is furthest back. Put curves and pins near
+        # the back. Nodes and markers nearer the front.
+        self.setZValue(0)
+
         self.addCurveLink()
         self.buildCurve()
-        self.setZValue(0) #Set Draw sorting order - 0 is furthest back. Put curves and pins near the back. Nodes and markers nearer the front.
 
     def getNodeList(self, controlNodes):
         """Function to collect and store control nodes as weak references"""
@@ -184,13 +190,29 @@ class RigCurve(QtGui.QGraphicsItem):
         return self.path.boundingRect()
 
     def paint(self, painter, option, widget):
+        "Recalculates the curve if it is dirty and paints it"
+
+        if self.dirty:
+            self.buildCurve()
+
         pen = QtGui.QPen(QtCore.Qt.black, 1.2, QtCore.Qt.DotLine)
         painter.setPen(pen)
         painter.setBrush(self.color)
         painter.strokePath(self.path, painter.pen())
 
+    def dirtyCurve(self):
+        "Marks the curve as dirty to register that it needs to be recalculated before drawing"
+
+        self.dirty = True
+
     def buildCurve(self):
-        """Function to build section of Bezier"""
+        "Rebuilds the curve if it is dirty and marks it as clean"
+
+        if not self.dirty:
+            return
+
+        self.dirty = False
+
         if self.isVisible:
             if len(self.nodeList) >= 3:
                 self.path = QtGui.QPainterPath()
@@ -246,6 +268,8 @@ class RigCurve(QtGui.QGraphicsItem):
                 cP1 = self.nodeList[-2]().getBezierHandles(1)
                 self.nodeList[-1]().setBezierHandles(cP2, 0)
                 self.path.cubicTo(QPVec(cP1),QPVec(cP2),QPVec(startPoint))
+
+
 
 
 


### PR DESCRIPTION
Details in the commit message. Basically turns out the the GraphicsView was already doing something like Maya anyway so the usual mark-as-dirty and recalculate-on-draw approach works well for improving the performance. Might be cleaner ways of doing it but this achieves the result for the moment.

I haven't merged this commit into master so if you do grab it, you'll want to pull it down and then do:

```
 git checkout master
 git merge --no-ff curve-performance
```

Good times!
